### PR TITLE
Add support for pulling from and uploading to azure devops artifacts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,40 +4,40 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>gcs.toolset</groupId>
     <artifactId>metrics</artifactId>
-	<version>1.0.3</version>
+    <version>1.0.3</version>
 
     <scm>
-		<connection>cm:git:git@github.com:GCS-Tech/gcs-metrics.git</connection>
-		<developerConnection>scm:git:git@github.com:GCS-Tech/gcs-metrics.git</developerConnection>
-		<url>https://github.com/GCS-Tech/gcs-metrics.git</url>
-		<tag>${project.version}</tag>
+        <connection>cm:git:git@github.com:GCS-Tech/gcs-metrics.git</connection>
+        <developerConnection>scm:git:git@github.com:GCS-Tech/gcs-metrics.git</developerConnection>
+        <url>https://github.com/GCS-Tech/gcs-metrics.git</url>
+        <tag>${project.version}</tag>
     </scm>
 
     <repositories>
-		<repository>
-			<id>q5id-packages</id>
-			<url>https://pkgs.dev.azure.com/q5id/_packaging/q5id-packages/maven/v1</url>
-			<releases>
-				<enabled>true</enabled>
-			</releases>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-		</repository>
-	</repositories>
+        <repository>
+            <id>q5id-packages</id>
+            <url>https://pkgs.dev.azure.com/q5id/_packaging/q5id-packages/maven/v1</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
 
-	<distributionManagement>
-		<repository>
-			<id>q5id-packages</id>
-			<url>https://pkgs.dev.azure.com/q5id/_packaging/q5id-packages/maven/v1</url>
-			<releases>
-				<enabled>true</enabled>
-			</releases>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-		</repository>
-	</distributionManagement>
+    <distributionManagement>
+        <repository>
+            <id>q5id-packages</id>
+            <url>https://pkgs.dev.azure.com/q5id/_packaging/q5id-packages/maven/v1</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </distributionManagement>
 
     <dependencies>
         <dependency>
@@ -122,17 +122,17 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-		<version>3.8.0</version>
+                <version>3.8.0</version>
 
-		<configuration>
-		  <source>12</source>
-		  <target>12</target>
-		  <encoding>UTF-8</encoding>
-		  <compilerArgs>
-		    <arg>--add-exports=java.base/jdk.internal.ref=ALL-UNNAMED</arg>
-		    <arg>--add-exports=java.base/sun.nio.ch=ALL-UNNAMED</arg>
-		  </compilerArgs>
-		</configuration>
+                <configuration>
+                    <source>12</source>
+                    <target>12</target>
+                    <encoding>UTF-8</encoding>
+                    <compilerArgs>
+                        <arg>--add-exports=java.base/jdk.internal.ref=ALL-UNNAMED</arg>
+                        <arg>--add-exports=java.base/sun.nio.ch=ALL-UNNAMED</arg>
+                    </compilerArgs>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,31 @@
 		<tag>${project.version}</tag>
     </scm>
 
+    <repositories>
+		<repository>
+			<id>q5id-packages</id>
+			<url>https://pkgs.dev.azure.com/q5id/_packaging/q5id-packages/maven/v1</url>
+			<releases>
+				<enabled>true</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</repository>
+	</repositories>
+
+	<distributionManagement>
+		<repository>
+			<id>q5id-packages</id>
+			<url>https://pkgs.dev.azure.com/q5id/_packaging/q5id-packages/maven/v1</url>
+			<releases>
+				<enabled>true</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</repository>
+	</distributionManagement>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
This adds support for pushing and pulling packages to our Azure Devops maven feed.

In order to upload new versions simply run `mvn deploy`. You will need to setup your `$HOME/.m2/settings.json` file with your AZDO Personal Access Token, [these instructions](https://docs.microsoft.com/en-us/azure/devops/artifacts/get-started-maven?view=azure-devops) do a good job showing how that looks.